### PR TITLE
cleanup drifted resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cdk.out
 !jest.config.js
 !.github/workflows/dependency-check.js
 !src/constructs/networking/vpc-peering-routes/lambda.js
+!src/constructs/compute/eks-cleanup/lambda.js

--- a/bundle.sh
+++ b/bundle.sh
@@ -1,1 +1,2 @@
 cp ./src/constructs/networking/vpc-peering-routes/lambda.js ./dist/constructs/networking/vpc-peering-routes/lambda.js;
+cp ./src/constructs/compute/eks-cleanup/lambda.js ./dist/constructs/compute/eks-cleanup/lambda.js;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinystacks/aws-cdk-constructs",
-  "version": "0.2.0",
+  "version": "0.2.1-local.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinystacks/aws-cdk-constructs",
-      "version": "0.2.0",
+      "version": "0.2.1-local.6",
       "license": "ISC",
       "dependencies": {
         "@tinystacks/iac-utils": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinystacks/aws-cdk-constructs",
-  "version": "0.2.0",
+  "version": "0.2.1-local.6",
   "description": "Modularized cdk constructs for use in building tailored stacks.",
   "main": "dist/index.js",
   "scope": "@tinystacks",

--- a/src/constructs/compute/eks-cleanup/index.ts
+++ b/src/constructs/compute/eks-cleanup/index.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Construct } from 'constructs';
+import { constructId } from '@tinystacks/iac-utils';
+import { PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Function, InlineCode, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { CustomResource, Duration } from 'aws-cdk-lib';
+import { Provider } from 'aws-cdk-lib/custom-resources';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+
+export interface EksCleanupProps {
+  vpcId: string;
+  clusterName: string;
+}
+
+export class EksCleanup extends Construct {
+  public readonly response: any;
+
+  constructor (scope: Construct, id: string, props: EksCleanupProps) {
+    super(scope, id);
+
+    const role = new Role(this, constructId('EksCleanupRole'), {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      inlinePolicies: {
+        functionPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: [
+                'ec2:DescribeNetworkInterfaces',
+                'ec2:DeleteNetworkInterface',
+                'ec2:DescribeSecurityGroups',
+                'ec2:DeleteSecurityGroup'
+              ],
+              resources: ['*']
+            })
+          ]
+        })
+      },
+      managedPolicies: [
+        {
+          managedPolicyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        }
+      ]
+    });
+    const fn = new Function(this, constructId('EksCleanupLambdaFunction'), {
+      code: new InlineCode(
+        fs.readFileSync(path.resolve(__dirname, './lambda.js'), { encoding: 'utf-8' })
+      ),
+      handler: 'index.handler',
+      timeout: Duration.seconds(300),
+      runtime: Runtime.NODEJS_16_X,
+      role,
+      logRetention: RetentionDays.THREE_MONTHS
+    });
+
+    const provider = new Provider(this, 'EksCleanupProvider', {
+      onEventHandler: fn
+    });
+
+    const resource = new CustomResource(this, 'EksCleanupResource', {
+      serviceToken: provider.serviceToken,
+      properties: props
+    });
+
+    this.response = resource.getAtt('Response').toString();
+  }
+}

--- a/src/constructs/compute/eks-cleanup/lambda.js
+++ b/src/constructs/compute/eks-cleanup/lambda.js
@@ -1,0 +1,124 @@
+/*eslint-env node*/
+const AWS = require('aws-sdk');
+const response = require('cfn-response');
+
+async function getEnis (ec2Client, nextToken) {
+  let params;
+  if (nextToken && nextToken !== 'next') {
+    params = { NextToken: nextToken };
+  }
+  const { NetworkInterfaces = [], NextToken } = await ec2Client.describeNetworkInterfaces(params).promise();
+
+  return { enis: NetworkInterfaces, nextToken: NextToken };
+}
+
+async function getSecurityGroups (ec2Client, nextToken, props) {
+  const params = {
+    Filters: [
+      {
+        Name: 'vpc-id',
+        Values: [props.vpcId]
+      }
+    ]
+  };
+  if (nextToken && nextToken !== 'next') {
+    params.NextToken = nextToken;
+  }
+  const { SecurityGroups: securityGroups = [], NextToken } = await ec2Client.describeSecurityGroups(params).promise();
+
+  return { securityGroups, nextToken: NextToken };
+}
+
+async function getDriftedEnis (ec2Client, props) {
+  const {
+    vpcId,
+    clusterName
+  } = props;
+  const driftedEnis = [];
+  const driftedEniPattern = `eks-cluster-sg-${clusterName}`;
+  let pageToken = 'next';
+  while (pageToken) {
+    const { enis = [], nextToken } = await getEnis(ec2Client, pageToken);
+    driftedEnis.push(
+      ...enis.filter(({ VpcId, Groups = [] }) => {
+        return VpcId === vpcId && Groups.some(sg => sg.GroupName.startsWith(driftedEniPattern));
+      })
+    );
+    pageToken = nextToken;
+  }
+  return driftedEnis;
+}
+
+async function getDriftedSecurityGroups (ec2Client, props) {
+  const {
+    vpcId,
+    clusterName
+  } = props;
+  const driftedSecurityGroups = [];
+  const driftedSgPattern = `eks-cluster-sg-${clusterName}`;
+  let pageToken = 'next';
+  while (pageToken) {
+    const { securityGroups = [], nextToken } = await getSecurityGroups(ec2Client, pageToken, props);
+    driftedSecurityGroups.push(
+      ...securityGroups.filter(({ VpcId, GroupName }) => {
+        return VpcId === vpcId && GroupName.startsWith(driftedSgPattern);
+      }
+      )
+    );
+    pageToken = nextToken;
+  }
+  return driftedSecurityGroups;
+}
+
+async function deleteDriftedEnis (ec2Client, props) {
+  const driftedEnis = await getDriftedEnis(ec2Client, props);
+  console.info('Plan is to delete the following enis: ', JSON.stringify(driftedEnis));
+  for (const eni of driftedEnis) {
+    const { NetworkInterfaceId } = eni;
+    await ec2Client.deleteNetworkInterface({ NetworkInterfaceId })
+      .promise()
+      .catch((error) => {
+        console.error(`Failed to delete ENI: ${NetworkInterfaceId}`);
+        console.error(error);
+        return;
+      });
+  }
+}
+
+async function deleteDriftedSecurityGroups (ec2Client, props) {
+  const driftedSecurityGroups = await getDriftedSecurityGroups(ec2Client, props);
+  console.info('Plan is to delete the following security groups: ', JSON.stringify(driftedSecurityGroups));
+  for (const sg of driftedSecurityGroups) {
+    const { SecurityGroupId } = sg;
+    await ec2Client.deleteSecurityGroup({ SecurityGroupId })
+      .promise()
+      .catch((error) => {
+        console.error(`Failed to delete security group: ${SecurityGroupId}`);
+        console.error(error);
+        return;
+      });
+  }
+}
+
+async function handler (event, context) {
+  const { ResourceProperties: props } = event;
+  try {
+    const ec2Client = new AWS.EC2();
+    if (event.RequestType === 'Delete') {
+      await deleteDriftedEnis(ec2Client, props);
+      await deleteDriftedSecurityGroups(ec2Client, props);
+      response.send(event, context, response.SUCCESS);
+      return;
+    } 
+    response.send(event, context, response.SUCCESS);
+    return;
+  } catch (error) {
+    console.error(error);
+    response.send(event, context, response.FAILED);
+    throw new Error('Failed to delete Lambda ENIs!');
+  }
+}
+
+module.exports = {
+  handler
+};


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix
 - [ ] Non-bug Patch (dependency updates, ci-cd updates, etc.)

## Link to Notion Task or Github Issue
<!-- Go to the task, press the ellipsis button (three dots), then click Copy Link -->
<!-- Example: -->
<!-- https://www.notion.so/tinystacks/Add-Linter-to-Templates-6b4b1910281842308c11d14961d01237 -->
https://www.notion.so/tinystacks/SG-and-ENI-doesn-t-delete-from-Galileo-stack-causing-delete-failures-f4110e609c02443a8d810ead0a565634

## Summary of Changes
<!-- Example: -->
<!--
For a new feature, describe what functionality is being added.
For a bug fix, describe the previous behaviour, the new behaviour, and its impact.
For a patch, descibe the changes, why they are necessary, and any potential impact.
-->
Previously, deletes would fail because of left over security groups and ENI's created from k8.
Now, we have a custom resource that deletes any leftover enis and sgs related to the EKS cluster after the EKS cluster has been deleted.

## Other details
<!-- Document any other important information or caveats to the PR here. -->

## Dependencies
<!-- List any dependencies here, for example if this PR depends on another PR, and include any pertinent links -->
<!-- If there are none, either leave this blank or list as N/A -->