### PR TITLE
EKS Construct

### DIFF
--- a/src/constructs/eks/eks_cluster.ts
+++ b/src/constructs/eks/eks_cluster.ts
@@ -1,0 +1,38 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as eks from 'aws-cdk-lib/aws-eks';
+import { Construct } from 'constructs';
+
+export interface EksClusterProps {
+  clusterName: string;
+  version: eks.KubernetesVersion;
+  vpc: ec2.Vpc;
+  subnetType: ec2.SubnetType;
+  managedPolicies: any[];
+}
+
+export class EksCluster extends Construct {
+
+  public readonly eks_cluster: eks.Cluster;
+
+  constructor (scope: Construct, id: string, props: EksClusterProps) {
+    super (scope, id);
+
+    const clusterRole = new iam.Role(this, 'eks-cluster-role', {
+      assumedBy: new iam.ServicePrincipal('eks.amazonaws.com'),
+      managedPolicies: props.managedPolicies
+    });
+
+    this.eks_cluster = new eks.Cluster(this, 'eks-cluster', {
+      clusterName: props.clusterName,
+      vpc: props.vpc,
+      version: props.version,
+      vpcSubnets: [
+        { subnetType: props.subnetType }
+      ],
+      role: clusterRole,
+      defaultCapacity: 0
+    });
+
+  }
+}

--- a/src/constructs/eks/eks_cluster.ts
+++ b/src/constructs/eks/eks_cluster.ts
@@ -2,6 +2,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as eks from 'aws-cdk-lib/aws-eks';
 import { Construct } from 'constructs';
+import { constructId } from '@tinystacks/iac-utils';
 
 export interface EksClusterProps {
   clusterName: string;
@@ -18,12 +19,12 @@ export class EksCluster extends Construct {
   constructor (scope: Construct, id: string, props: EksClusterProps) {
     super (scope, id);
 
-    const clusterRole = new iam.Role(this, 'eks-cluster-role', {
+    const clusterRole = new iam.Role(this, constructId('eks', 'cluster', 'role'), {
       assumedBy: new iam.ServicePrincipal('eks.amazonaws.com'),
       managedPolicies: props.managedPolicies
     });
 
-    this.eks_cluster = new eks.Cluster(this, 'eks-cluster', {
+    this.eks_cluster = new eks.Cluster(this, constructId('eks', 'cluster'), {
       clusterName: props.clusterName,
       vpc: props.vpc,
       version: props.version,

--- a/src/constructs/eks/eks_nodegroup.ts
+++ b/src/constructs/eks/eks_nodegroup.ts
@@ -2,6 +2,7 @@ import * as eks from 'aws-cdk-lib/aws-eks';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
+import { constructId } from '@tinystacks/iac-utils';
 
 export interface EksNodegroupProps {
   nodegroupName: string;
@@ -24,12 +25,12 @@ export class EksNodegroup extends Construct {
   constructor (scope: Construct, id: string, props: EksNodegroupProps) {
     super (scope, id);
 
-    const nodegroupRole = new iam.Role(this, 'eks-nodegroup-role', {
+    const nodegroupRole = new iam.Role(this, constructId('eks', 'nodegroup', 'role'), {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
       managedPolicies: props.managedPolicies
     });
 
-    props.eksCluster.addNodegroupCapacity ('node-group', {
+    props.eksCluster.addNodegroupCapacity (constructId('node', 'group'), {
       nodegroupName: props.nodegroupName,
       minSize: props.nodeMinSize,
       maxSize: props.nodeMaxSize,

--- a/src/constructs/eks/eks_nodegroup.ts
+++ b/src/constructs/eks/eks_nodegroup.ts
@@ -1,0 +1,46 @@
+import * as eks from 'aws-cdk-lib/aws-eks';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+export interface EksNodegroupProps {
+  nodegroupName: string;
+  nodeMinSize: number;
+  nodeMaxSize: number;
+  nodeDesiredSize: number;
+  nodeDiskSize: number;
+  eksCluster: eks.Cluster;
+  managedPolicies: any[];
+  subnets: ec2.SubnetSelection;
+  tags?: {};
+  amiType: eks.NodegroupAmiType;
+  instanceTypes: any[];
+}
+
+export class EksNodegroup extends Construct {
+
+  public readonly eks_nodegroup: eks.Nodegroup;
+
+  constructor (scope: Construct, id: string, props: EksNodegroupProps) {
+    super (scope, id);
+
+    const nodegroupRole = new iam.Role(this, 'eks-nodegroup-role', {
+      assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+      managedPolicies: props.managedPolicies
+    });
+
+    props.eksCluster.addNodegroupCapacity ('node-group', {
+      nodegroupName: props.nodegroupName,
+      minSize: props.nodeMinSize,
+      maxSize: props.nodeMaxSize,
+      desiredSize: props.nodeDesiredSize,
+      diskSize: props.nodeDiskSize,
+      subnets: props.subnets,
+      tags: props.tags,
+      amiType: props.amiType,
+      instanceTypes: props.instanceTypes,
+      nodeRole: nodegroupRole,
+    });
+
+  }
+}


### PR DESCRIPTION
Example of how to initialize it

```
import * as cdk from 'aws-cdk-lib';
import * as ec2 from 'aws-cdk-lib/aws-ec2';
import * as iam from 'aws-cdk-lib/aws-iam';
import * as eks from 'aws-cdk-lib/aws-eks';
import { VpcStack } from './vpc'
import { EksCluster } from './eks_cluster'
import { EksNodegroup } from './eks_nodegroup'

    const helloVpcStack = new VpcStack(this, 'helloVpcStack');


    const helloEksClusterStack = new EksCluster(this, 'helloEksStack', {
      clusterName: 'ajtest',
      vpc: helloVpcStack.vpc,
      managedPolicies: [
        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSClusterPolicy'),
        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSVPCResourceController')
      ],
      version: eks.KubernetesVersion.V1_19,
      subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
    });

    new EksNodegroup(this, 'helloEksCoreNodegroupStack', {
      nodegroupName: 'coreNodegroup',
      eksCluster: helloEksClusterStack.eks_cluster,
      nodeMinSize: 1,
      nodeMaxSize: 5,
      nodeDesiredSize: 3,
      nodeDiskSize: 50,
      amiType: eks.NodegroupAmiType.BOTTLEROCKET_X86_64,
      instanceTypes: [new ec2.InstanceType('t3.small')],
      managedPolicies: [
        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSWorkerNodePolicy'),
        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ContainerRegistryReadOnly'),
        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEKS_CNI_Policy'),
        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSVPCResourceController')
      ],
      subnets: helloVpcStack.vpc.selectSubnets({
        subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS
      }),
    });
```