### PR TITLE
ECS Construct

### DIFF
--- a/src/constructs/ecs/ecs_cluster.ts
+++ b/src/constructs/ecs/ecs_cluster.ts
@@ -1,0 +1,32 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import { Construct } from 'constructs';
+
+export interface EcsClusterProps {
+  clusterName: string;
+  vpc: ec2.Vpc;
+  instanceType: ec2.InstanceType;
+  machineImage: ec2.IMachineImage;
+  desiredCapacity: number;
+}
+
+export class EcsCluster extends Construct {
+
+  public readonly ecsCluster: ecs.Cluster;
+
+  constructor (scope: Construct, id: string, props: EcsClusterProps) {
+    super (scope, id);
+
+    this.ecsCluster = new ecs.Cluster(this, 'ecs-cluster', {
+      clusterName: props.clusterName,
+      vpc: props.vpc
+    });
+
+    this.ecsCluster.addCapacity('ecs-cluster-add-capacity', {
+      instanceType: props.instanceType,
+      machineImage: props.machineImage,
+      desiredCapacity: props.desiredCapacity,
+    });
+  
+  }
+}

--- a/src/constructs/ecs/ecs_service.ts
+++ b/src/constructs/ecs/ecs_service.ts
@@ -1,0 +1,80 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as cdk from 'aws-cdk-lib';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Construct } from 'constructs';
+import { cpus } from 'os';
+
+export interface EcsServiceProps {
+  containerName: string;
+  vpc: ec2.Vpc;
+  ecsCluster: ecs.Cluster;
+  containerImage: string;
+  memoryLimitMiB: number;
+  cpu: number;
+  applicationPort: number;
+
+}
+
+export class EcsService extends Construct {
+
+  readonly ecsAlb: elbv2.ApplicationLoadBalancer;
+
+  constructor (scope: Construct, id: string, props: EcsServiceProps) {
+    super (scope, id);
+
+    const taskDefinition = new ecs.Ec2TaskDefinition(this, 'ecs-ec2-task-definition');
+
+    const ecsContainer = taskDefinition.addContainer("ecs-container", {
+      containerName: props.containerName,
+      image: ecs.ContainerImage.fromRegistry(props.containerImage),
+      memoryLimitMiB: props.memoryLimitMiB,
+      cpu: props.cpu,
+    });
+
+    ecsContainer.addPortMappings({
+      containerPort: props.applicationPort,
+      hostPort: props.applicationPort,
+      protocol: ecs.Protocol.TCP
+    });
+
+    const ecsService = new ecs.Ec2Service(this, "ecs-ec2-service", {
+      cluster: props.ecsCluster,
+      taskDefinition: taskDefinition,
+    });
+
+    this.ecsAlb = new elbv2.ApplicationLoadBalancer(this, 'ecs-alb', {
+      vpc: props.vpc,
+      internetFacing: true
+    });
+
+    const ecsListener = this.ecsAlb.addListener('EcsListener', {
+      port: 80,
+      open: true
+    });
+
+    ecsListener.addTargets('ECS', {
+      port: props.applicationPort,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      targets: [ecsService.loadBalancerTarget({
+        containerName: props.containerName,
+        containerPort: props.applicationPort
+      })],
+      healthCheck: {
+        interval: cdk.Duration.seconds(60),
+        path: "/health",
+        timeout: cdk.Duration.seconds(5),
+      }
+    });
+
+    new cdk.CfnOutput(this, 'ECSLoadBalancerDNS', {
+      value: this.ecsAlb.loadBalancerDnsName
+    });
+  
+  }
+
+  public get EcsServiceDnsName (): string {
+    return this.ecsAlb.loadBalancerDnsName;
+  }
+
+}


### PR DESCRIPTION
Notion Task: https://www.notion.so/tinystacks/ECS-CDK-Module-b0e28f2ac7dc467c8019b945773d723b

I will add the constructIds to standardize it.

```
    const helloVpcStack = new VpcStack(this, 'helloVpcStack');


    const helloEcsClusterStack = new EcsCluster(this, 'helloEcsClusterStack', {
      clusterName: 'aj-ecs-cluster',
      vpc: helloVpcStack.vpc,
      instanceType: new ec2.InstanceType("t2.micro"),
      machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
      desiredCapacity: 1
    });

    new EcsService(this, 'helloEcsServiceStack', {
      containerName: 'acme-api',
      vpc: helloVpcStack.vpc,
      ecsCluster: helloEcsClusterStack.ecsCluster,
      containerImage: 'ajjester/acme-api:latest',
      memoryLimitMiB: 512,
      cpu: 256,
      applicationPort: 3000,

    });
```