### PR TITLE
default assignPublicIp to false, allow user to set

### DIFF
--- a/src/constructs/compute/ecs-service.ts
+++ b/src/constructs/compute/ecs-service.ts
@@ -29,6 +29,7 @@ export interface EcsServiceProps {
   ecsTaskEnvVars: { [key: string]: string; };
   secrets?: { [key: string]: Secret; }
   command?: string[];
+  assignPublicIp?: boolean;
 }
 
 export class EcsService extends Construct {
@@ -68,12 +69,13 @@ export class EcsService extends Construct {
 
     ecsContainer.addPortMappings({ containerPort: props.applicationPort });
 
+    const { assignPublicIp = false } = props;
     this.ecsService = new ecs.FargateService(this, constructId('ecs', 'FargfateService'), {
       cluster: props.ecsCluster,
       desiredCount: props.desiredCount,
       taskDefinition: ecsTaskDefinition,
       securityGroups: [props.ecsSecurityGroup],
-      assignPublicIp: true,
+      assignPublicIp,
       enableExecuteCommand: true
     });
 


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix
 - [ ] Non-bug Patch (dependency updates, ci-cd updates, etc.)

## Link to Notion Task or Github Issue
N/A - Prod support

## Summary of Changes
The `assignPublicIp` property on the Service was set to true.  This is unnecessary and typically undesirable.  Now we default this to false but allow the user to set the value themselves.